### PR TITLE
When an error happens, show the deepest cause instead of the shallowest

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,13 @@ The firmware is compatible with my LG smart TV remote control. The following but
 * TV/Radio
 
 To use a different remote control, open the serial monitor and look at the IR codes that are sent when you press the desired buttons. Then change the constants in `config.h` accordingly.
+
+## Errors
+
+When sening a command to the speaker, something can go wrong.
+
+The display will show `E` followed by another letter if an error occurred:
+* `EA` if the speaker hasn't yet been found in the network;
+* `Et` if the speaker didn't reply on time (HTTP request timeout);
+* `Eh` if the speaker replied with an HTTP error code;
+* `EP` if the firmware wasn't able to parse the speaker response.

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -11,7 +11,7 @@
 
 const unsigned long kTextDisplayDuration = 1500;
 
-const byte kNumChars = 24;
+const byte kNumChars = 28;
 const byte kDisplayFont[kNumChars][2] = {
   // ch    ABCDEFGd
   { ' ', 0b00000000 },
@@ -26,14 +26,18 @@ const byte kDisplayFont[kNumChars][2] = {
   { '7', 0b11100000 },
   { '8', 0b11111110 },
   { '9', 0b11110110 },
+  { 'A', 0b11101110 },
   { 'E', 0b10011110 },
   { 'H', 0b01101110 },
+  { 'h', 0b00101110 },
+  { 'O', 0b11111100 },
   { 'S', 0b10110110 },
   { 'e', 0b10011110 },
   { 'i', 0b00001000 },
   { 'm', 0b00101010 },
   { 'n', 0b00101010 },
   { 'o', 0b00111010 },
+  { 'P', 0b11001110 },
   { 's', 0b10110110 },
   { 't', 0b00011110 },
   { 'u', 0b00111000 },

--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,28 @@
+#pragma once
+
+/**
+ * Definition of result of an operation, either OK or an error value.
+ */
+enum class Result {
+    /** The operation was completed successfully. */
+    OK,
+
+    /** We don't know (yet) the speaker address. */
+    ERROR_NO_SPEAKER_ADDRESS,
+
+    /** The speaker didn't reply on time, e.g. it's off or its IP address has changed. */
+    ERROR_HTTP_TIMEOUT,
+
+    /** The speaker's HTTP server replied with something different than 200 OK. */
+    ERROR_HTTP_NON_OK_RESPONSE,
+
+    /** The speaker's HTTP response couldn't be understood. */
+    ERROR_PARSE_FAILED
+};
+
+/**
+ * Implements a simple error propagation. To be used in a function returning Result, when
+ * invoking another function returning Result. If the returned result is not OK, this macro
+ * will propagate the error to the calling function.
+ */
+#define RETURN_IF_ERROR(x) { Result result = (x); if (result != Result::OK) return result; }

--- a/src/http_response.h
+++ b/src/http_response.h
@@ -2,7 +2,8 @@
 
 #include <Arduino.h>
 #include <asyncHTTPrequest.h>
+#include "error.h"
 
-bool waitForHttpOkResponse(asyncHTTPrequest &request);
-bool parseValueInXML(String document, String &output, String openTag, String closeTag);
-bool getValueFromHttp(asyncHTTPrequest &request, String &output, String openTag, String closeTag);
+Result waitForHttpOkResponse(asyncHTTPrequest &request);
+Result parseValueInXML(String document, String &output, String openTag, String closeTag);
+Result getValueFromHttp(asyncHTTPrequest &request, String &output, String openTag, String closeTag);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,25 +57,25 @@ void onHttpWait() {
 }
 
 void onVolumeUp() {
-  if (!increaseVolume(speaker)) {
+  if (increaseVolume(speaker) != Result::OK) {
     notifyVolumeFail();
   }
 }
 
 void onVolumeDown() {
-  if (!decreaseVolume(speaker)) {
+  if (decreaseVolume(speaker) != Result::OK) {
     notifyVolumeFail();
   }
 }
 
 void onTvRad() {
-  if (!speaker.setTvInput()) {
+  if (speaker.setTvInput() != Result::OK) {
     notifyTvFail();
   }
 }
 
 void onMute() {
-  if (!toggleMute(speaker)) {
+  if (toggleMute(speaker) != Result::OK) {
     notifyMuteFail();
   }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,17 +57,25 @@ void onHttpWait() {
 }
 
 void onVolumeUp() {
-  increaseVolume(speaker);
+  if (!increaseVolume(speaker)) {
+    notifyVolumeFail();
+  }
 }
 
 void onVolumeDown() {
-  decreaseVolume(speaker);
+  if (!decreaseVolume(speaker)) {
+    notifyVolumeFail();
+  }
 }
 
 void onTvRad() {
-  speaker.setTvInput();
+  if (!speaker.setTvInput()) {
+    notifyTvFail();
+  }
 }
 
 void onMute() {
-  toggleMute(speaker);
+  if (!toggleMute(speaker)) {
+    notifyMuteFail();
+  }
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,25 +57,29 @@ void onHttpWait() {
 }
 
 void onVolumeUp() {
-  if (increaseVolume(speaker) != Result::OK) {
-    notifyVolumeFail();
+  Result result = increaseVolume(speaker);
+  if (result != Result::OK) {
+    notifyFail(result);
   }
 }
 
 void onVolumeDown() {
-  if (decreaseVolume(speaker) != Result::OK) {
-    notifyVolumeFail();
+  Result result = decreaseVolume(speaker);
+  if (result != Result::OK) {
+    notifyFail(result);
   }
 }
 
 void onTvRad() {
-  if (speaker.setTvInput() != Result::OK) {
-    notifyTvFail();
+  Result result = speaker.setTvInput();
+  if (result != Result::OK) {
+    notifyFail(result);
   }
 }
 
 void onMute() {
-  if (toggleMute(speaker) != Result::OK) {
-    notifyMuteFail();
+  Result result = toggleMute(speaker);
+  if (result != Result::OK) {
+    notifyFail(result);
   }
 }

--- a/src/notify.cpp
+++ b/src/notify.cpp
@@ -76,10 +76,6 @@ void notifyTv(bool wasSet) {
   displayText(wasSet ? " tv." : " tv");
 }
 
-void notifyTvFail() {
-  notifyAuxFail();
-}
-
 void notifyAuxGetSuccess(bool isAux) {
   notifyTv(false);
 }
@@ -88,6 +84,9 @@ void notifyAuxSetSuccess(bool isAux) {
 }
 void notifyAuxFail() {
   notifyFail(kDisplayErrorCodeAux);
+}
+void notifyTvFail() {
+  notifyAuxFail();
 }
 
 void notifyMuteGetSuccess() {

--- a/src/notify.cpp
+++ b/src/notify.cpp
@@ -3,10 +3,6 @@
 #include "display.h"
 #include "config.h"
 
-const char kDisplayErrorCodeVolume = 'v';
-const char kDisplayErrorCodeAux = 't';
-const char kDisplayErrorCodeMute = 'n';
-
 void animate(char ch) {
   String text = "    ";
   int dashPos = (millis() / 600) % 4;
@@ -55,10 +51,26 @@ void notifyVolume(int volume, bool wasSet) {
   displayText(text);
 }
 
-void notifyFail(char code) {
-  String text = "  E";
-  text += code;
-  displayText(text);
+void notifyFail(Result result) {
+  switch(result) {
+  case Result::OK:
+    displayText("  OH"); // error: no error?
+    break;
+  case Result::ERROR_NO_SPEAKER_ADDRESS:
+    displayText("  EA");
+    break;
+  case Result::ERROR_HTTP_TIMEOUT:
+    displayText("  Et");
+    break;
+  case Result::ERROR_HTTP_NON_OK_RESPONSE:
+    displayText("  Eh");
+    break;
+  case Result::ERROR_PARSE_FAILED:
+    displayText("  EP");
+    break;
+  default:
+    displayText("  E_");
+  }
 }
 
 void notifyVolumeGetSuccess(int volume) {
@@ -66,9 +78,6 @@ void notifyVolumeGetSuccess(int volume) {
 }
 void notifyVolumeSetSuccess(int volume) {
   notifyVolume(volume, true);
-}
-void notifyVolumeFail() {
-  notifyFail(kDisplayErrorCodeVolume);
 }
 
 
@@ -82,19 +91,10 @@ void notifyAuxGetSuccess(bool isAux) {
 void notifyAuxSetSuccess(bool isAux) {
   notifyTv(true);
 }
-void notifyAuxFail() {
-  notifyFail(kDisplayErrorCodeAux);
-}
-void notifyTvFail() {
-  notifyAuxFail();
-}
 
 void notifyMuteGetSuccess() {
-  displayText("mu?");
+  displayText("mu");
 }
 void notifyMuteSetSuccess(bool isMute) {
   displayText(isMute ? "mute." : "soun.");
-}
-void notifyMuteFail() {
-  notifyFail(kDisplayErrorCodeMute);
 }

--- a/src/notify.cpp
+++ b/src/notify.cpp
@@ -55,26 +55,20 @@ void notifyVolume(int volume, bool wasSet) {
   displayText(text);
 }
 
-void notifyFail(char code, bool duringSet) {
+void notifyFail(char code) {
   String text = "  E";
   text += code;
-  if (duringSet) {
-    text += ".";
-  }
   displayText(text);
 }
 
 void notifyVolumeGetSuccess(int volume) {
   notifyVolume(volume, false);
 }
-void notifyVolumeGetFail() {
-  notifyFail(kDisplayErrorCodeVolume, false);
-}
 void notifyVolumeSetSuccess(int volume) {
   notifyVolume(volume, true);
 }
-void notifyVolumeSetFail() {
-  notifyFail(kDisplayErrorCodeVolume, true);
+void notifyVolumeFail() {
+  notifyFail(kDisplayErrorCodeVolume);
 }
 
 
@@ -83,31 +77,25 @@ void notifyTv(bool wasSet) {
 }
 
 void notifyTvFail() {
-  notifyAuxSetFail();
+  notifyAuxFail();
 }
 
 void notifyAuxGetSuccess(bool isAux) {
   notifyTv(false);
 }
-void notifyAuxGetFail() {
-  notifyFail(kDisplayErrorCodeAux, false);
-}
 void notifyAuxSetSuccess(bool isAux) {
   notifyTv(true);
 }
-void notifyAuxSetFail() {
-  notifyFail(kDisplayErrorCodeAux, true);
+void notifyAuxFail() {
+  notifyFail(kDisplayErrorCodeAux);
 }
 
 void notifyMuteGetSuccess() {
   displayText("mu?");
 }
-void notifyMuteGetFail() {
-  notifyFail(kDisplayErrorCodeMute, false);
-}
 void notifyMuteSetSuccess(bool isMute) {
   displayText(isMute ? "mute." : "soun.");
 }
-void notifyMuteSetFail() {
-  notifyFail(kDisplayErrorCodeMute, true);
+void notifyMuteFail() {
+  notifyFail(kDisplayErrorCodeMute);
 }

--- a/src/notify.h
+++ b/src/notify.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <Arduino.h>
+
+void notifyNoSpeaker();
+void notifySpeakerAddress(String address);
+
+void notifyVolumeGetSuccess(int volume);
+void notifyVolumeGetFail();
+void notifyVolumeSetSuccess(int volume);
+void notifyVolumeSetFail();
+
+void notifyAuxGetSuccess(bool isAux);
+void notifyAuxGetFail();
+void notifyAuxSetSuccess(bool isAux);
+void notifyAuxSetFail();
+
+void notifyTv(bool wasSet);
+void notifyTvFail();
+
+void notifyMuteGetSuccess();
+void notifyMuteGetFail();
+void notifyMuteSetSuccess(bool isMuted);
+void notifyMuteSetFail();

--- a/src/notify.h
+++ b/src/notify.h
@@ -1,21 +1,20 @@
 #pragma once
 
 #include <Arduino.h>
+#include "error.h"
 
 void notifyNoSpeaker();
 void notifySpeakerAddress(String address);
 
 void notifyVolumeGetSuccess(int volume);
 void notifyVolumeSetSuccess(int volume);
-void notifyVolumeFail();
 
 void notifyAuxGetSuccess(bool isAux);
 void notifyAuxSetSuccess(bool isAux);
-void notifyAuxFail();
 
 void notifyTv(bool wasSet);
-void notifyTvFail();
 
 void notifyMuteGetSuccess();
 void notifyMuteSetSuccess(bool isMuted);
-void notifyMuteFail();
+
+void notifyFail(Result result);

--- a/src/notify.h
+++ b/src/notify.h
@@ -6,19 +6,16 @@ void notifyNoSpeaker();
 void notifySpeakerAddress(String address);
 
 void notifyVolumeGetSuccess(int volume);
-void notifyVolumeGetFail();
 void notifyVolumeSetSuccess(int volume);
-void notifyVolumeSetFail();
+void notifyVolumeFail();
 
 void notifyAuxGetSuccess(bool isAux);
-void notifyAuxGetFail();
 void notifyAuxSetSuccess(bool isAux);
-void notifyAuxSetFail();
+void notifyAuxFail();
 
 void notifyTv(bool wasSet);
 void notifyTvFail();
 
 void notifyMuteGetSuccess();
-void notifyMuteGetFail();
 void notifyMuteSetSuccess(bool isMuted);
-void notifyMuteSetFail();
+void notifyMuteFail();

--- a/src/speaker.h
+++ b/src/speaker.h
@@ -2,6 +2,7 @@
 
 #include <Arduino.h>
 #include "notify.h"
+#include "error.h"
 
 /**
  * Controls an IP-accessible audio speaker.
@@ -19,48 +20,43 @@ struct Speaker {
      */
     virtual bool isAddressValid() = 0;
 
-    /**
-     * Special value returned by getVolume() when a connection error occurred.
-     */
-    static const int kGetVolumeError = -1;
-
     /** 
      * Queries the speaker for the current volume level.
      * This function will make an HTTP request and will call onHttpWait() while waiting for the response.
      * \param outVolume the current speaker volume. The magnitude is device-specific.
-     * \return true if the read was successful, false otherwise.
+     * \return the result of the query
      */
-    virtual bool getVolume(int &outVolume) = 0;
+    virtual Result getVolume(int &outVolume) = 0;
 
     /**
      * Sets the speaker volume.
      * This function will make an HTTP request and will call onHttpWait() while waiting for the response.
      * \param newVolume the desired volume as a non-negative number. The bounds are device-specific, and no checks are made.
-     * \return true if the set was successful, false otherwise.
+     * \return the result of the operation
      */
-    virtual bool setVolume(int newVolume) = 0;
+    virtual Result setVolume(int newVolume) = 0;
 
     /**
      * Sets the speaker's audio input to the TV corresponding to the IR remote being used.
      * Will call notify* functions to indicate the progress.
      * This function will make an HTTP request and will call onHttpWait() while waiting for the response.
-     * \return true if the set was successful, false otherwise.
+     * \return the result of the operation
      */
-    virtual bool setTvInput() = 0;
+    virtual Result setTvInput() = 0;
 
     /**
      * Queries the speaker for the current mute status.
      * This function will make an HTTP request and will call onHttpWait() while waiting for the response.
      * \param outStatus the variable that will contain the mute status. True means that the spaker is muted.
-     * \return true if the query was successful, false otherwise.
+     * \return the result of the query
      */
-    virtual bool getMuteStatus(bool &outStatus) = 0;
+    virtual Result getMuteStatus(bool &outStatus) = 0;
 
     /**
      * Sets the speaker mute status.
      * This function will make an HTTP request and will call onHttpWait() while waiting for the response.
      * \param newMuteStatus the desired mute status. True means that the speaker is muted.
-     * \return true if the set was successful, false otherwise.
+     * \return the result of the operation
      */
-    virtual bool setMuteStatus(const bool newMuteStatus) = 0;
+    virtual Result setMuteStatus(const bool newMuteStatus) = 0;
 };

--- a/src/speaker.h
+++ b/src/speaker.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include "notify.h"
 
 /**
  * Controls an IP-accessible audio speaker.
@@ -63,27 +64,3 @@ struct Speaker {
      */
     virtual bool setMuteStatus(const bool newMuteStatus) = 0;
 };
-
-
-
-// The functions below are callbacks. Their definition must be in a file other than speaker.cpp.
-void notifyNoSpeaker();
-void notifySpeakerAddress(String address);
-
-void notifyVolumeGetSuccess(int volume);
-void notifyVolumeGetFail();
-void notifyVolumeSetSuccess(int volume);
-void notifyVolumeSetFail();
-
-void notifyAuxGetSuccess(bool isAux);
-void notifyAuxGetFail();
-void notifyAuxSetSuccess(bool isAux);
-void notifyAuxSetFail();
-
-void notifyTv(bool wasSet);
-void notifyTvFail();
-
-void notifyMuteGetSuccess();
-void notifyMuteGetFail();
-void notifyMuteSetSuccess(bool isMuted);
-void notifyMuteSetFail();

--- a/src/speaker.h
+++ b/src/speaker.h
@@ -26,10 +26,10 @@ struct Speaker {
     /** 
      * Queries the speaker for the current volume level.
      * This function will make an HTTP request and will call onHttpWait() while waiting for the response.
-     * \return the volume level as a non-negative number, or kGetVolumeError if an error occurred.
-     * The magnitude is device-specific
+     * \param outVolume the current speaker volume. The magnitude is device-specific.
+     * \return true if the read was successful, false otherwise.
      */
-    virtual int getVolume() = 0;
+    virtual bool getVolume(int &outVolume) = 0;
 
     /**
      * Sets the speaker volume.

--- a/src/speaker.h
+++ b/src/speaker.h
@@ -26,14 +26,15 @@ struct Speaker {
     /** 
      * Queries the speaker for the current volume level.
      * This function will make an HTTP request and will call onHttpWait() while waiting for the response.
-     * \return the volume level from 0 to 30, or kGetVolumeError if an error occurred.
+     * \return the volume level as a non-negative number, or kGetVolumeError if an error occurred.
+     * The magnitude is device-specific
      */
     virtual int getVolume() = 0;
 
     /**
      * Sets the speaker volume.
      * This function will make an HTTP request and will call onHttpWait() while waiting for the response.
-     * \param newVolume the desired volume from 0 to 30. Note that no bounds check is made.
+     * \param newVolume the desired volume as a non-negative number. The bounds are device-specific, and no checks are made.
      * \return true if the set was successful, false otherwise.
      */
     virtual bool setVolume(int newVolume) = 0;

--- a/src/speaker_musiccast.cpp
+++ b/src/speaker_musiccast.cpp
@@ -20,14 +20,15 @@ bool MusicCastSpeaker::isAddressValid()
     return waitForHttpOkResponse(request);
 }
 
-int MusicCastSpeaker::getVolume()
+bool MusicCastSpeaker::getVolume(int &outVolume)
 {
     DynamicJsonDocument doc(384);
     if (!getStatus(doc)) {
-        return kGetVolumeError;
+        return false;
     }
 
-    return doc["volume"];
+    outVolume = doc["volume"];
+    return true;
 }
 
 

--- a/src/speaker_musiccast.cpp
+++ b/src/speaker_musiccast.cpp
@@ -56,7 +56,6 @@ bool MusicCastSpeaker::setTvInput()
     notifyTv(false);
     bool success = powerOn();
     if (!success) {
-        notifyTvFail();
         return false;        
     }
 
@@ -71,7 +70,6 @@ bool MusicCastSpeaker::setTvInput()
     request.send();
     if (!checkSuccess()) 
     {
-        notifyTvFail();
         return false;
     }
 
@@ -80,10 +78,6 @@ bool MusicCastSpeaker::setTvInput()
     if (success)
     {
         notifyTv(true);
-    }
-    else
-    {
-        notifyTvFail();
     }
     return success;
 }

--- a/src/speaker_musiccast.h
+++ b/src/speaker_musiccast.h
@@ -12,7 +12,7 @@ public:
     void setAddress(const String &address);
     bool isAddressValid();
 
-    int getVolume();
+    bool getVolume(int &outVolume);
     bool setVolume(int newVolume);
 
     bool setTvInput();

--- a/src/speaker_musiccast.h
+++ b/src/speaker_musiccast.h
@@ -12,23 +12,23 @@ public:
     void setAddress(const String &address);
     bool isAddressValid();
 
-    bool getVolume(int &outVolume);
-    bool setVolume(int newVolume);
+    Result getVolume(int &outVolume);
+    Result setVolume(int newVolume);
 
-    bool setTvInput();
+    Result setTvInput();
 
-    bool getMuteStatus(bool &outStatus);
-    bool setMuteStatus(const bool newMuteStatus);
+    Result getMuteStatus(bool &outStatus);
+    Result setMuteStatus(const bool newMuteStatus);
 
 private:
     String ipAddress;
     asyncHTTPrequest request;
-    bool getZoneUrl(String &output, const String &endPart);
-    bool getSystemUrl(String &output, const String &endPart);
-    bool checkSuccess();
-    bool getStatus(DynamicJsonDocument &outputDoc);
-    bool powerOn();
-    bool setABSpeakers();
-    bool setABSpeaker(const char &letter, const bool enable);
+    Result getZoneUrl(String &output, const String &endPart);
+    Result getSystemUrl(String &output, const String &endPart);
+    Result checkSuccess();
+    Result getStatus(DynamicJsonDocument &outputDoc);
+    Result powerOn();
+    Result setABSpeakers();
+    Result setABSpeaker(const char &letter, const bool enable);
 };
 

--- a/src/speaker_samsung_multiroom.cpp
+++ b/src/speaker_samsung_multiroom.cpp
@@ -124,7 +124,7 @@ bool SamsungMultiroomSpeaker::setTvInput() {
     bool success = isInputSourceAux(isAux);
     if (!success) {
       USE_SERIAL.println("unable to get input source");
-      notifyAuxGetFail();
+      notifyAuxFail();
       return false;
     }
   }
@@ -150,7 +150,7 @@ bool SamsungMultiroomSpeaker::setTvInput() {
   if (success) {
     notifyAuxSetSuccess(isAux);
   } else {
-    notifyAuxSetFail();
+    notifyAuxFail();
   }
   return success;
 }

--- a/src/speaker_samsung_multiroom.cpp
+++ b/src/speaker_samsung_multiroom.cpp
@@ -25,19 +25,19 @@ void SamsungMultiroomSpeaker::setAddress(const String &address) {
   speakerIpAddress = address;
 }
 
-bool SamsungMultiroomSpeaker::getQueryUrl(String &output, String command) {
+Result SamsungMultiroomSpeaker::getQueryUrl(String &output, String command) {
   if (speakerIpAddress.isEmpty()) {
-    return false;
+    return Result::ERROR_HTTP_TIMEOUT;
   }
 
   output = "http://" + speakerIpAddress + ":55001/UIC?cmd=%3Cname%3E" + command + "%3C/name%3E";
   
-  return true;
+  return Result::OK;
 }
 
-bool SamsungMultiroomSpeaker::getSingleParamCommandUrl(String &output, String command, String paramType, String paramName, String paramValue) {
+Result SamsungMultiroomSpeaker::getSingleParamCommandUrl(String &output, String command, String paramType, String paramName, String paramValue) {
   if (speakerIpAddress.isEmpty()) {
-    return false;
+    return Result::ERROR_NO_SPEAKER_ADDRESS;
   }
 
   output = "http://" + speakerIpAddress + ":55001/UIC?cmd="
@@ -48,31 +48,26 @@ bool SamsungMultiroomSpeaker::getSingleParamCommandUrl(String &output, String co
     "%20name%3D%22" + paramName + "%22"
     "%20val%3D%22" + paramValue + "%22"
     "/%3E";
-  return true;
+  return Result::OK;
 }
 
-int SamsungMultiroomSpeaker::getVolumeFromHttp() {
+Result SamsungMultiroomSpeaker::getVolumeFromHttp(int &outVolume) {
   String valueString;
-  bool success = getValueFromHttp(request, valueString, kVolumeOpenTag, kVolumeCloseTag);
-  if (!success) {
-    return kGetVolumeError;
-  }
-  return valueString.toInt();
+  RETURN_IF_ERROR(getValueFromHttp(request, valueString, kVolumeOpenTag, kVolumeCloseTag))
+  outVolume = valueString.toInt();
+  return Result::OK;
 }
 
-bool SamsungMultiroomSpeaker::getVolume(int &outVolume) {
+Result SamsungMultiroomSpeaker::getVolume(int &outVolume) {
   String url;
-  if (!getQueryUrl(url, "GetVolume")) {
-    return false;
-  }
+  RETURN_IF_ERROR(getQueryUrl(url, "GetVolume"))
 
   request.open("GET", url.c_str());
   request.send();
-  outVolume = getVolumeFromHttp();
-  return true;
+  return getVolumeFromHttp(outVolume);
 }
 
-bool SamsungMultiroomSpeaker::checkSuccess() {
+Result SamsungMultiroomSpeaker::checkSuccess() {
   while (request.readyState() != 4) {
     yield();
     onHttpWait();
@@ -81,17 +76,15 @@ bool SamsungMultiroomSpeaker::checkSuccess() {
   int httpCode = request.responseHTTPcode();
   if (httpCode != 200 /* OK */) {
     USE_SERIAL.printf("[HTTP] GET not OK, code: %d\n", httpCode);
-    return false;
+    return Result::ERROR_HTTP_NON_OK_RESPONSE;
   }
 
-  return true;
+  return Result::OK;
 }
 
-bool SamsungMultiroomSpeaker::setVolume(int newVolume) {
+Result SamsungMultiroomSpeaker::setVolume(int newVolume) {
   String url;
-  if (!getSingleParamCommandUrl(url, "SetVolume", "dec", "volume", String(newVolume))) {
-    return false;
-  }
+  RETURN_IF_ERROR(getSingleParamCommandUrl(url, "SetVolume", "dec", "volume", String(newVolume)))
 
   request.open("GET", url.c_str());
   request.send();
@@ -99,84 +92,61 @@ bool SamsungMultiroomSpeaker::setVolume(int newVolume) {
 }
 
 // return value is success/failure; actual output is in param reference
-bool SamsungMultiroomSpeaker::isInputSourceAux(bool &isAux) {
+Result SamsungMultiroomSpeaker::isInputSourceAux(bool &isAux) {
   String url;
-  if (!getQueryUrl(url, "GetFunc")) {
-    return false;
-  }
+  RETURN_IF_ERROR(getQueryUrl(url, "GetFunc"))
   request.open("GET", url.c_str());
   request.send();
   String inputSource;
-  bool success = getValueFromHttp(request, inputSource, kInputSourceOpenTag, kInputSourceCloseTag);
-  if (!success) {
-    return false;
-  }
+  RETURN_IF_ERROR(getValueFromHttp(request, inputSource, kInputSourceOpenTag, kInputSourceCloseTag))
   USE_SERIAL.print("[");
   USE_SERIAL.print(inputSource);
   USE_SERIAL.print("]");
   isAux = inputSource == kInputSourceAux;
-  return true;
+  return Result::OK;
 }
 
-bool SamsungMultiroomSpeaker::setTvInput() {
+Result SamsungMultiroomSpeaker::setTvInput() {
   bool isAux;
-  {
-    bool success = isInputSourceAux(isAux);
-    if (!success) {
-      USE_SERIAL.println("unable to get input source");
-      return false;
-    }
-  }
+  RETURN_IF_ERROR(isInputSourceAux(isAux))
   notifyAuxGetSuccess(isAux);
 
   if (isAux) {
     USE_SERIAL.println("already AUX; not setting again");
     notifyAuxSetSuccess(isAux);
-    return true;
+    return Result::OK;
   }
 
   USE_SERIAL.print("set AUX... ");
   String url;
-  if (!getSingleParamCommandUrl(url, "SetFunc", "str", "function", "aux")) {
-    return false;
-  }
+  RETURN_IF_ERROR(getSingleParamCommandUrl(url, "SetFunc", "str", "function", "aux"))
 
   request.open("GET", url.c_str());
   request.send();
-  bool success = checkSuccess();
+  RETURN_IF_ERROR(checkSuccess())
 
-  USE_SERIAL.println(success ? "OK" : "fail :(");
-  if (success) {
-    notifyAuxSetSuccess(isAux);
-  }
-  return success;
+  notifyAuxSetSuccess(isAux);
+  return Result::OK;
 }
 
-bool SamsungMultiroomSpeaker::getMuteStatus(bool &muteStatus) {
+Result SamsungMultiroomSpeaker::getMuteStatus(bool &muteStatus) {
   String url;
-  if (!getQueryUrl(url, "GetMute")) {
-    return false;
-  }
+  RETURN_IF_ERROR(getQueryUrl(url, "GetMute"))
   request.open("GET", url.c_str());
   request.send();
   String muteString;
-  bool success = getValueFromHttp(request, muteString, kMuteOpenTag, kMuteCloseTag);
-  if (!success) {
-    return false;
-  }
+  RETURN_IF_ERROR(getValueFromHttp(request, muteString, kMuteOpenTag, kMuteCloseTag))
   USE_SERIAL.print("[");
   USE_SERIAL.print(muteString);
   USE_SERIAL.print("]");
   muteStatus = muteString == kMuteOn;
-  return true;
+  return Result::OK;
 }
 
 
-bool SamsungMultiroomSpeaker::setMuteStatus(const bool muteStatus) {
+Result SamsungMultiroomSpeaker::setMuteStatus(const bool muteStatus) {
   String url;
-  if (!getSingleParamCommandUrl(url, "SetMute", "str", "mute", muteStatus ? "on" : "off")) {
-    return false;
-  }
+  RETURN_IF_ERROR(getSingleParamCommandUrl(url, "SetMute", "str", "mute", muteStatus ? "on" : "off"))
   request.open("GET", url.c_str());
   request.send();
   return checkSuccess();
@@ -184,7 +154,7 @@ bool SamsungMultiroomSpeaker::setMuteStatus(const bool muteStatus) {
 
 bool SamsungMultiroomSpeaker::isAddressValid() {
   String url;
-  if (!getQueryUrl(url, "GetVolume")) {
+  if (getQueryUrl(url, "GetVolume") != Result::OK) {
     return false;
   }
 
@@ -192,10 +162,5 @@ bool SamsungMultiroomSpeaker::isAddressValid() {
   request.send();
 
   String valueString;
-  bool success = getValueFromHttp(request, valueString, kVolumeOpenTag, kVolumeCloseTag);
-  if (!success) {
-    return false;
-  }
-
-  return true;
+  return getValueFromHttp(request, valueString, kVolumeOpenTag, kVolumeCloseTag) == Result::OK;
 }

--- a/src/speaker_samsung_multiroom.cpp
+++ b/src/speaker_samsung_multiroom.cpp
@@ -60,16 +60,16 @@ int SamsungMultiroomSpeaker::getVolumeFromHttp() {
   return valueString.toInt();
 }
 
-int SamsungMultiroomSpeaker::getVolume() {
+bool SamsungMultiroomSpeaker::getVolume(int &outVolume) {
   String url;
   if (!getQueryUrl(url, "GetVolume")) {
-    return kGetVolumeError;
+    return false;
   }
 
   request.open("GET", url.c_str());
   request.send();
-  int volume = getVolumeFromHttp();
-  return volume;
+  outVolume = getVolumeFromHttp();
+  return true;
 }
 
 bool SamsungMultiroomSpeaker::checkSuccess() {

--- a/src/speaker_samsung_multiroom.cpp
+++ b/src/speaker_samsung_multiroom.cpp
@@ -124,7 +124,6 @@ bool SamsungMultiroomSpeaker::setTvInput() {
     bool success = isInputSourceAux(isAux);
     if (!success) {
       USE_SERIAL.println("unable to get input source");
-      notifyAuxFail();
       return false;
     }
   }
@@ -149,8 +148,6 @@ bool SamsungMultiroomSpeaker::setTvInput() {
   USE_SERIAL.println(success ? "OK" : "fail :(");
   if (success) {
     notifyAuxSetSuccess(isAux);
-  } else {
-    notifyAuxFail();
   }
   return success;
 }

--- a/src/speaker_samsung_multiroom.h
+++ b/src/speaker_samsung_multiroom.h
@@ -11,21 +11,21 @@ public:
     void setAddress(const String &address);
     bool isAddressValid();
 
-    bool getVolume(int &outVolume);
-    bool setVolume(int newVolume);
+    Result getVolume(int &outVolume);
+    Result setVolume(int newVolume);
 
-    bool setTvInput();
+    Result setTvInput();
 
-    bool getMuteStatus(bool &muteStatus);
-    bool setMuteStatus(const bool muteStatus);
+    Result getMuteStatus(bool &muteStatus);
+    Result setMuteStatus(const bool muteStatus);
 
 private:
-    bool getQueryUrl(String &output, String command);
-    bool getSingleParamCommandUrl(String &output, String command, String paramType, String paramName, String paramValue);
+    Result getQueryUrl(String &output, String command);
+    Result getSingleParamCommandUrl(String &output, String command, String paramType, String paramName, String paramValue);
 
-    int getVolumeFromHttp();
-    bool checkSuccess();
-    bool isInputSourceAux(bool &isAux);
+    Result getVolumeFromHttp(int &outVolume);
+    Result checkSuccess();
+    Result isInputSourceAux(bool &isAux);
     void checkSpeakerIpAddress();
 
     String speakerIpAddress;

--- a/src/speaker_samsung_multiroom.h
+++ b/src/speaker_samsung_multiroom.h
@@ -11,7 +11,7 @@ public:
     void setAddress(const String &address);
     bool isAddressValid();
 
-    int getVolume();
+    bool getVolume(int &outVolume);
     bool setVolume(int newVolume);
 
     bool setTvInput();

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -4,14 +4,10 @@
 #include "serial.h"
 #include "config.h"
 
-bool setVolumeDelta(Speaker& speaker, int delta) {
+Result setVolumeDelta(Speaker& speaker, int delta) {
   USE_SERIAL.print("... ");
   int volume;
-  bool success;
-  success = speaker.getVolume(volume);
-  if (!success) {
-    return false;
-  }
+  RETURN_IF_ERROR(speaker.getVolume(volume))
   notifyVolumeGetSuccess(volume);
   int newVolume = volume + delta;
   // prevent going out of bounds
@@ -23,51 +19,38 @@ bool setVolumeDelta(Speaker& speaker, int delta) {
   if (newVolume == volume) {
     // skip an HTTP request just to set the same volume
     USE_SERIAL.print("(skip) ");
-    success = true;
   } else {
     USE_SERIAL.print(" ... ");
-    success = speaker.setVolume(newVolume);
+    RETURN_IF_ERROR(speaker.setVolume(newVolume))
   }
-  if (success) {
-    notifyVolumeSetSuccess(newVolume);
-  }
-  return success;
+  notifyVolumeSetSuccess(newVolume);
+  return Result::OK;
 }
 
-bool increaseVolume(Speaker& speaker) {
+Result increaseVolume(Speaker& speaker) {
   USE_SERIAL.print("VOL+ ");
-  bool success = setVolumeDelta(speaker, kVolumeUpStep);
-  USE_SERIAL.println(success ? "OK" : "fail :(");
-  return success;
+  RETURN_IF_ERROR(setVolumeDelta(speaker, kVolumeUpStep))
+  return Result::OK;
 }
 
-bool decreaseVolume(Speaker& speaker) {
+Result decreaseVolume(Speaker& speaker) {
   USE_SERIAL.print("VOL- ");
-  bool success = setVolumeDelta(speaker, kVolumeDownStep);
-  USE_SERIAL.println(success ? "OK" : "fail :(");
-  return success;
+  RETURN_IF_ERROR(setVolumeDelta(speaker, kVolumeDownStep))
+  return Result::OK;
 }
 
 
-bool toggleMute(Speaker &speaker) {
+Result toggleMute(Speaker &speaker) {
   bool isMuted;
   USE_SERIAL.print("Mute: ");
-  bool getSuccess = speaker.getMuteStatus(isMuted);
-  if (!getSuccess) {
-    USE_SERIAL.println("unable to get mute state");
-    return false;
-  }
+  RETURN_IF_ERROR(speaker.getMuteStatus(isMuted))
   notifyMuteGetSuccess();
   USE_SERIAL.print(isMuted ? "on" : "off");
   USE_SERIAL.print(" => ");
 
-  bool setSuccess = speaker.setMuteStatus(!isMuted);
-  if (!setSuccess) {
-    USE_SERIAL.println("fail :(");
-    return false;
-  }
+  RETURN_IF_ERROR(speaker.setMuteStatus(!isMuted))
 
   USE_SERIAL.println(!isMuted ? "on" : "off");
   notifyMuteSetSuccess(!isMuted);
-  return true;
+  return Result::OK;
 }

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -10,7 +10,7 @@ bool setVolumeDelta(Speaker& speaker, int delta) {
   bool success;
   success = speaker.getVolume(volume);
   if (!success) {
-    notifyVolumeGetFail();
+    notifyVolumeFail();
     return false;
   }
   notifyVolumeGetSuccess(volume);
@@ -32,7 +32,7 @@ bool setVolumeDelta(Speaker& speaker, int delta) {
   if (success) {
     notifyVolumeSetSuccess(newVolume);
   } else {
-    notifyVolumeSetFail();
+    notifyVolumeFail();
   }
   return success;
 }
@@ -56,7 +56,7 @@ bool toggleMute(Speaker &speaker) {
   bool getSuccess = speaker.getMuteStatus(isMuted);
   if (!getSuccess) {
     USE_SERIAL.println("unable to get mute state");
-    notifyMuteGetFail();
+    notifyMuteFail();
     return false;
   }
   notifyMuteGetSuccess();
@@ -66,7 +66,7 @@ bool toggleMute(Speaker &speaker) {
   bool setSuccess = speaker.setMuteStatus(!isMuted);
   if (!setSuccess) {
     USE_SERIAL.println("fail :(");
-    notifyMuteSetFail();
+    notifyMuteFail();
     return false;
   }
 

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -6,8 +6,10 @@
 
 bool setVolumeDelta(Speaker& speaker, int delta) {
   USE_SERIAL.print("... ");
-  int volume = speaker.getVolume();
-  if (volume == Speaker::kGetVolumeError) {
+  int volume;
+  bool success;
+  success = speaker.getVolume(volume);
+  if (!success) {
     notifyVolumeGetFail();
     return false;
   }
@@ -19,7 +21,6 @@ bool setVolumeDelta(Speaker& speaker, int delta) {
   USE_SERIAL.print(" => ");
   USE_SERIAL.print(newVolume);
   USE_SERIAL.print(" ");
-  bool success;
   if (newVolume == volume) {
     // skip an HTTP request just to set the same volume
     USE_SERIAL.print("(skip) ");

--- a/src/volume.cpp
+++ b/src/volume.cpp
@@ -10,7 +10,6 @@ bool setVolumeDelta(Speaker& speaker, int delta) {
   bool success;
   success = speaker.getVolume(volume);
   if (!success) {
-    notifyVolumeFail();
     return false;
   }
   notifyVolumeGetSuccess(volume);
@@ -31,22 +30,22 @@ bool setVolumeDelta(Speaker& speaker, int delta) {
   }
   if (success) {
     notifyVolumeSetSuccess(newVolume);
-  } else {
-    notifyVolumeFail();
   }
   return success;
 }
 
-void increaseVolume(Speaker& speaker) {
+bool increaseVolume(Speaker& speaker) {
   USE_SERIAL.print("VOL+ ");
   bool success = setVolumeDelta(speaker, kVolumeUpStep);
   USE_SERIAL.println(success ? "OK" : "fail :(");
+  return success;
 }
 
-void decreaseVolume(Speaker& speaker) {
+bool decreaseVolume(Speaker& speaker) {
   USE_SERIAL.print("VOL- ");
   bool success = setVolumeDelta(speaker, kVolumeDownStep);
   USE_SERIAL.println(success ? "OK" : "fail :(");
+  return success;
 }
 
 
@@ -56,7 +55,6 @@ bool toggleMute(Speaker &speaker) {
   bool getSuccess = speaker.getMuteStatus(isMuted);
   if (!getSuccess) {
     USE_SERIAL.println("unable to get mute state");
-    notifyMuteFail();
     return false;
   }
   notifyMuteGetSuccess();
@@ -66,7 +64,6 @@ bool toggleMute(Speaker &speaker) {
   bool setSuccess = speaker.setMuteStatus(!isMuted);
   if (!setSuccess) {
     USE_SERIAL.println("fail :(");
-    notifyMuteFail();
     return false;
   }
 

--- a/src/volume.h
+++ b/src/volume.h
@@ -2,6 +2,6 @@
 
 #include "speaker.h"
 
-void increaseVolume(Speaker& speaker);
-void decreaseVolume(Speaker& speaker); 
+bool increaseVolume(Speaker& speaker);
+bool decreaseVolume(Speaker& speaker); 
 bool toggleMute(Speaker &speaker);

--- a/src/volume.h
+++ b/src/volume.h
@@ -2,6 +2,6 @@
 
 #include "speaker.h"
 
-bool increaseVolume(Speaker& speaker);
-bool decreaseVolume(Speaker& speaker); 
-bool toggleMute(Speaker &speaker);
+Result increaseVolume(Speaker& speaker);
+Result decreaseVolume(Speaker& speaker); 
+Result toggleMute(Speaker &speaker);


### PR DESCRIPTION
If I turn up the volume and the speaker is unreachable, the firmware used to signal an error while changing the volume. That's useless (I know what I was doing).
With this PR it signals the specific operation that failed. So in the case above, it will signal an HTTP timeout error, which helps more to troubleshoot the problem.